### PR TITLE
feat: #1 - Fecha límite opcional en tareas

### DIFF
--- a/app_docs/conditional_docs.md
+++ b/app_docs/conditional_docs.md
@@ -1,0 +1,12 @@
+# Conditional Documentation
+
+Este fichero indica qué documentación leer según el contexto de trabajo.
+
+## Entradas
+
+- app_docs/feature-1-due-date-tasks.md
+  - Condiciones:
+    - Cuando se trabaje con el campo `due_date` en el modelo Task o la tabla `tasks`
+    - Cuando se implemente lógica de indicadores visuales de fechas en TaskItem
+    - Cuando se resuelvan problemas relacionados con validación de fechas en creación de tareas
+    - Cuando se añadan o modifiquen campos opcionales en el formulario de tareas

--- a/app_docs/feature-1-due-date-tasks.md
+++ b/app_docs/feature-1-due-date-tasks.md
@@ -1,0 +1,87 @@
+# Feature: Fecha Límite Opcional en Tareas (due_date)
+
+**ADW ID:** 25302f69
+**Fecha:** 2026-03-04
+**Especificacion:** .issues/1/plan.md
+
+## Overview
+
+Se añadió un campo de fecha límite (`due_date`) opcional a las tareas de la aplicación Todo List. Las tareas pueden tener una fecha de vencimiento que se muestra con indicadores visuales de color según su proximidad: rojo para tareas vencidas y naranja para tareas que vencen pronto. Las tareas completadas no muestran indicadores de urgencia.
+
+## Que se Construyo
+
+- Campo `due_date` (tipo `date`, nullable) en la tabla `tasks` de la base de datos
+- Validación en el modelo: no se permiten fechas pasadas al crear una tarea (permite null y edición de tareas existentes)
+- Input de fecha en el formulario de creación de tareas (`TaskForm`)
+- Indicadores visuales de color en `TaskItem` según el estado de la fecha (vencida/próxima/normal)
+- Soporte en la API REST para enviar y recibir `due_date`
+- Suite completa de tests unitarios e integración para backend y frontend
+
+## Implementacion Tecnica
+
+### Ficheros Modificados
+
+- `backend/db/migrate/20260304144557_add_due_date_to_tasks.rb`: Migración para añadir columna `due_date date` nullable a la tabla `tasks`
+- `backend/db/schema.rb`: Columna `due_date` añadida al schema de la tabla `tasks`
+- `backend/app/models/task.rb`: Validación de `due_date` (no fechas pasadas en creación, permite nil)
+- `backend/app/controllers/api/tasks_controller.rb`: `:due_date` añadido a los strong parameters
+- `backend/test/fixtures/tasks.yml`: Fixture actualizado con `due_date` (3 días desde ahora)
+- `backend/test/models/task_test.rb`: Tests unitarios de validación de `due_date`
+- `backend/test/controllers/api/tasks_controller_test.rb`: Tests de integración CRUD con `due_date`
+- `frontend/src/services/api.js`: `createTask` acepta y envía `dueDate` como `due_date`
+- `frontend/src/components/TaskForm.jsx`: Estado `dueDate` y input `type="date"` añadidos
+- `frontend/src/App.jsx`: `handleCreateTask` pasa `dueDate` al servicio API
+- `frontend/src/components/TaskItem.jsx`: Lógica de estado de fecha y renderizado con estilos dinámicos
+- `frontend/src/index.css`: Estilos `.task-date-input`, `.due-date`, `.due-date--overdue`, `.due-date--soon`
+- `frontend/src/__tests__/TaskForm.test.jsx`: Tests del formulario con fecha
+- `frontend/src/__tests__/TaskItem.test.jsx`: Tests de indicadores visuales
+
+### Cambios Clave
+
+1. **Migración y Schema**: Columna `due_date date` nullable añadida a `tasks`; el campo es completamente opcional.
+2. **Validación de modelo**: `validates :due_date, comparison: { greater_than_or_equal_to: Date.today }, allow_nil: true, on: :create` — solo rechaza fechas pasadas al crear; permite actualizar tareas existentes con cualquier fecha.
+3. **Lógica de estado en TaskItem**: Función `getDueDateStatus(dueDate, completed)` que calcula `'overdue'` (fecha pasada), `'soon'` (≤1 día restante) o `null`; retorna `null` para tareas completadas o sin fecha.
+4. **Formato localizado**: Fecha formateada con `toLocaleDateString('es-ES')` (ej: "25 dic 2026").
+5. **CSS adaptativo**: Clases `.due-date--overdue` (rojo, negrita) y `.due-date--soon` (naranja, negrita) aplicadas dinámicamente; tareas completadas nunca muestran indicadores de urgencia.
+
+## Como Usar
+
+1. Abre la aplicación Todo List en el navegador.
+2. En el formulario de creación de tareas, introduce el título de la tarea.
+3. Opcionalmente, selecciona una fecha límite usando el campo de fecha (debe ser hoy o una fecha futura).
+4. Haz clic en "Añadir" para crear la tarea.
+5. La tarea aparece en la lista con la fecha formateada:
+   - Sin color especial si la fecha está en el futuro (más de 1 día).
+   - **Naranja** si vence hoy o mañana.
+   - **Rojo** si ya venció y la tarea no está completada.
+6. Al marcar la tarea como completada, los indicadores de color desaparecen.
+
+## Configuracion
+
+No se requiere configuración adicional. El campo es nullable en la base de datos y opcional en el formulario.
+
+- La validación de fecha pasada aplica únicamente en la creación (`on: :create`).
+- El formateo de fecha usa el locale `es-ES` para consistencia con la UI en español.
+
+## Testing
+
+**Backend:**
+```bash
+cd backend && bin/rails test
+```
+- `task_test.rb`: Valida nil, fecha futura válida, fecha pasada inválida en creación.
+- `tasks_controller_test.rb`: Crear con fecha, crear sin fecha, actualizar fecha, eliminar fecha (set null).
+
+**Frontend:**
+```bash
+cd frontend && npm test -- --run
+```
+- `TaskForm.test.jsx`: Renderiza input de fecha, envío con/sin fecha, limpieza de campos.
+- `TaskItem.test.jsx`: Muestra fecha formateada, indicadores `overdue`/`soon`, ausencia de indicadores en tareas completadas.
+
+## Notas
+
+- La validación de fecha pasada solo aplica en `on: :create`, permitiendo que tareas existentes con fechas vencidas puedan seguir siendo editadas sin errores.
+- Los indicadores visuales se desactivan automáticamente en tareas completadas para evitar ruido visual innecesario.
+- No se requieren gemas ni paquetes npm adicionales.
+- El campo `due_date` es compatible con el flujo de actualización (PATCH): puede modificarse o eliminarse (set a null) en cualquier momento.

--- a/backend/app/controllers/api/tasks_controller.rb
+++ b/backend/app/controllers/api/tasks_controller.rb
@@ -56,7 +56,7 @@ class Api::TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:title, :completed, :position)
+    params.require(:task).permit(:title, :completed, :position, :due_date)
   end
 
   def record_not_found

--- a/backend/app/models/task.rb
+++ b/backend/app/models/task.rb
@@ -4,20 +4,18 @@
 #
 #  id         :bigint           not null, primary key
 #  completed  :boolean          default(FALSE), not null
-#  position   :integer          default(0), not null
+#  due_date   :date
+#  position   :integer          not null
 #  title      :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#
-# Indexes
-#
-#  index_tasks_on_position  (position)
 #
 class Task < ApplicationRecord
   default_scope { order(:position) }
 
   validates :title, presence: true
   validates :title, length: { maximum: 200 }
+  validates :due_date, comparison: { greater_than_or_equal_to: -> { Date.today } }, allow_nil: true, on: :create
 
   before_create :set_default_position
 

--- a/backend/db/migrate/20260304144557_add_due_date_to_tasks.rb
+++ b/backend/db/migrate/20260304144557_add_due_date_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddDueDateToTasks < ActiveRecord::Migration[8.1]
+  def change
+    add_column :tasks, :due_date, :date
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_24_175121) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_04_144557) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
   create_table "tasks", force: :cascade do |t|
     t.boolean "completed", default: false, null: false
     t.datetime "created_at", null: false
+    t.date "due_date"
     t.integer "position", default: 0, null: false
     t.string "title", null: false
     t.datetime "updated_at", null: false

--- a/backend/test/controllers/api/tasks_controller_test.rb
+++ b/backend/test/controllers/api/tasks_controller_test.rb
@@ -149,4 +149,52 @@ class Api::TasksControllerTest < ActionDispatch::IntegrationTest
     positions = json_response.map { |t| t["position"] }
     assert_equal positions.sort, positions
   end
+
+  # Tests de due_date
+  test "should create task with due_date" do
+    future_date = 5.days.from_now.to_date.to_s
+
+    assert_difference("Task.count", 1) do
+      post api_tasks_url, params: { task: { title: "Task with date", due_date: future_date } }, as: :json
+    end
+
+    assert_response :created
+    json_response = JSON.parse(response.body)
+    assert_equal future_date, json_response["due_date"]
+  end
+
+  test "should create task without due_date" do
+    assert_difference("Task.count", 1) do
+      post api_tasks_url, params: { task: { title: "Task without date" } }, as: :json
+    end
+
+    assert_response :created
+    json_response = JSON.parse(response.body)
+    assert_nil json_response["due_date"]
+  end
+
+  test "should update due_date of existing task" do
+    task = tasks(:one)
+    new_date = 10.days.from_now.to_date.to_s
+
+    patch api_task_url(task), params: { task: { due_date: new_date } }, as: :json
+
+    assert_response :success
+    json_response = JSON.parse(response.body)
+    assert_equal new_date, json_response["due_date"]
+
+    task.reload
+    assert_equal new_date, task.due_date.to_s
+  end
+
+  test "should remove due_date by setting to null" do
+    task = tasks(:one)
+    assert_not_nil task.due_date
+
+    patch api_task_url(task), params: { task: { due_date: nil } }, as: :json
+
+    assert_response :success
+    task.reload
+    assert_nil task.due_date
+  end
 end

--- a/backend/test/fixtures/tasks.yml
+++ b/backend/test/fixtures/tasks.yml
@@ -4,19 +4,17 @@
 #
 #  id         :bigint           not null, primary key
 #  completed  :boolean          default(FALSE), not null
-#  position   :integer          default(0), not null
+#  due_date   :date
+#  position   :integer          not null
 #  title      :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#
-# Indexes
-#
-#  index_tasks_on_position  (position)
 #
 one:
   title: "Buy groceries"
   completed: false
   position: 0
+  due_date: <%= 3.days.from_now.to_date %>
 
 two:
   title: "Finish homework"

--- a/backend/test/models/task_test.rb
+++ b/backend/test/models/task_test.rb
@@ -4,14 +4,11 @@
 #
 #  id         :bigint           not null, primary key
 #  completed  :boolean          default(FALSE), not null
-#  position   :integer          default(0), not null
+#  due_date   :date
+#  position   :integer          not null
 #  title      :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#
-# Indexes
-#
-#  index_tasks_on_position  (position)
 #
 require "test_helper"
 
@@ -59,5 +56,22 @@ class TaskTest < ActiveSupport::TestCase
     tasks = Task.all
     positions = tasks.map(&:position)
     assert_equal positions.sort, positions
+  end
+
+  test "valid task with due_date nil" do
+    task = Task.new(title: "Task without due date")
+    assert task.valid?
+    assert_nil task.due_date
+  end
+
+  test "valid task with future due_date" do
+    task = Task.new(title: "Task with future date", due_date: 7.days.from_now.to_date)
+    assert task.valid?
+  end
+
+  test "invalid task with past due_date on create" do
+    task = Task.new(title: "Task with past date", due_date: 1.day.ago.to_date)
+    assert_not task.valid?
+    assert_includes task.errors[:due_date], "must be greater than or equal to #{Date.today}"
   end
 end

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -16,8 +16,8 @@ function App() {
     setTasks(data)
   }
 
-  const handleCreateTask = async (title) => {
-    const newTask = await createTask(title)
+  const handleCreateTask = async (title, dueDate) => {
+    const newTask = await createTask(title, dueDate)
     setTasks([...tasks, newTask])
   }
 

--- a/frontend/src/__tests__/App.test.jsx
+++ b/frontend/src/__tests__/App.test.jsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import App from '../App'
-import { fetchTasks, updateTask } from '../services/api'
+import { fetchTasks, createTask, updateTask } from '../services/api'
 
 // Mock del servicio API
 vi.mock('../services/api', () => ({
@@ -48,5 +48,23 @@ test('toggle calls updateTask with completed: false when task is completed', asy
 
   await waitFor(() => {
     expect(updateTask).toHaveBeenCalledWith(1, { completed: false })
+  })
+})
+
+test('create task with due date calls createTask with title and date', async () => {
+  fetchTasks.mockResolvedValue([])
+  createTask.mockResolvedValue({ id: 2, title: 'Dated task', completed: false, due_date: '2026-12-31' })
+
+  render(<App />)
+
+  const titleInput = screen.getByPlaceholderText(/nueva tarea/i)
+  const dateInput = document.querySelector('input[type="date"]')
+
+  fireEvent.change(titleInput, { target: { value: 'Dated task' } })
+  fireEvent.change(dateInput, { target: { value: '2026-12-31' } })
+  fireEvent.submit(screen.getByRole('button', { name: /añadir/i }))
+
+  await waitFor(() => {
+    expect(createTask).toHaveBeenCalledWith('Dated task', '2026-12-31')
   })
 })

--- a/frontend/src/__tests__/TaskForm.test.jsx
+++ b/frontend/src/__tests__/TaskForm.test.jsx
@@ -7,6 +7,12 @@ test('renders input and button', () => {
   expect(screen.getByRole('button', { name: /añadir/i })).toBeInTheDocument()
 })
 
+test('renders date input', () => {
+  render(<TaskForm onTaskCreated={() => {}} />)
+  const dateInput = document.querySelector('input[type="date"]')
+  expect(dateInput).toBeInTheDocument()
+})
+
 test('calls onTaskCreated when form is submitted', async () => {
   const mockCreate = vi.fn().mockResolvedValue()
   render(<TaskForm onTaskCreated={mockCreate} />)
@@ -16,7 +22,35 @@ test('calls onTaskCreated when form is submitted', async () => {
   fireEvent.submit(screen.getByRole('button'))
 
   await waitFor(() => {
-    expect(mockCreate).toHaveBeenCalledWith('Test task')
+    expect(mockCreate).toHaveBeenCalledWith('Test task', null)
+  })
+})
+
+test('sends task with due date', async () => {
+  const mockCreate = vi.fn().mockResolvedValue()
+  render(<TaskForm onTaskCreated={mockCreate} />)
+
+  const input = screen.getByPlaceholderText(/nueva tarea/i)
+  const dateInput = document.querySelector('input[type="date"]')
+  fireEvent.change(input, { target: { value: 'Task with date' } })
+  fireEvent.change(dateInput, { target: { value: '2026-12-31' } })
+  fireEvent.submit(screen.getByRole('button'))
+
+  await waitFor(() => {
+    expect(mockCreate).toHaveBeenCalledWith('Task with date', '2026-12-31')
+  })
+})
+
+test('sends task without due date', async () => {
+  const mockCreate = vi.fn().mockResolvedValue()
+  render(<TaskForm onTaskCreated={mockCreate} />)
+
+  const input = screen.getByPlaceholderText(/nueva tarea/i)
+  fireEvent.change(input, { target: { value: 'Task no date' } })
+  fireEvent.submit(screen.getByRole('button'))
+
+  await waitFor(() => {
+    expect(mockCreate).toHaveBeenCalledWith('Task no date', null)
   })
 })
 
@@ -25,10 +59,13 @@ test('clears input after submission', async () => {
   render(<TaskForm onTaskCreated={mockCreate} />)
 
   const input = screen.getByPlaceholderText(/nueva tarea/i)
+  const dateInput = document.querySelector('input[type="date"]')
   fireEvent.change(input, { target: { value: 'Test task' } })
+  fireEvent.change(dateInput, { target: { value: '2026-12-31' } })
   fireEvent.submit(screen.getByRole('button'))
 
   await waitFor(() => {
     expect(input.value).toBe('')
+    expect(dateInput.value).toBe('')
   })
 })

--- a/frontend/src/__tests__/TaskItem.test.jsx
+++ b/frontend/src/__tests__/TaskItem.test.jsx
@@ -60,3 +60,33 @@ test('renders drag handle', () => {
   const handle = document.querySelector('.drag-handle')
   expect(handle).toBeInTheDocument()
 })
+
+test('shows due date when it exists', () => {
+  const taskWithDate = { ...mockTask, due_date: '2026-12-25' }
+  render(<TaskItem task={taskWithDate} onToggle={() => {}} onDelete={() => {}} />)
+  expect(screen.getByText(/25/)).toBeInTheDocument()
+  expect(screen.getByText(/dic/i)).toBeInTheDocument()
+})
+
+test('does not show due date when it does not exist', () => {
+  render(<TaskItem task={mockTask} onToggle={() => {}} onDelete={() => {}} />)
+  const dueDate = document.querySelector('.due-date')
+  expect(dueDate).not.toBeInTheDocument()
+})
+
+test('shows overdue indicator for past due date on incomplete task', () => {
+  const overdueTask = { ...mockTask, due_date: '2020-01-01', completed: false }
+  render(<TaskItem task={overdueTask} onToggle={() => {}} onDelete={() => {}} />)
+  const dueDate = document.querySelector('.due-date--overdue')
+  expect(dueDate).toBeInTheDocument()
+})
+
+test('shows soon indicator for tomorrow due date on incomplete task', () => {
+  const tomorrow = new Date()
+  tomorrow.setDate(tomorrow.getDate() + 1)
+  const tomorrowStr = tomorrow.toISOString().split('T')[0]
+  const soonTask = { ...mockTask, due_date: tomorrowStr, completed: false }
+  render(<TaskItem task={soonTask} onToggle={() => {}} onDelete={() => {}} />)
+  const dueDate = document.querySelector('.due-date--soon')
+  expect(dueDate).toBeInTheDocument()
+})

--- a/frontend/src/components/TaskForm.jsx
+++ b/frontend/src/components/TaskForm.jsx
@@ -2,12 +2,14 @@ import { useState } from 'react'
 
 function TaskForm({ onTaskCreated }) {
   const [title, setTitle] = useState('')
+  const [dueDate, setDueDate] = useState('')
 
   const handleSubmit = async (e) => {
     e.preventDefault()
     if (title.trim()) {
-      await onTaskCreated(title)
+      await onTaskCreated(title, dueDate || null)
       setTitle('')
+      setDueDate('')
     }
   }
 
@@ -19,6 +21,12 @@ function TaskForm({ onTaskCreated }) {
         onChange={(e) => setTitle(e.target.value)}
         placeholder="Nueva tarea..."
         className="task-input"
+      />
+      <input
+        type="date"
+        value={dueDate}
+        onChange={(e) => setDueDate(e.target.value)}
+        className="task-date-input"
       />
       <button type="submit" className="btn btn-primary">
         Añadir

--- a/frontend/src/components/TaskItem.jsx
+++ b/frontend/src/components/TaskItem.jsx
@@ -1,6 +1,22 @@
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 
+function getDueDateStatus(dueDate, completed) {
+  if (!dueDate || completed) return null
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const due = new Date(dueDate + 'T00:00:00')
+  const diffDays = Math.ceil((due - today) / (1000 * 60 * 60 * 24))
+  if (diffDays < 0) return 'overdue'
+  if (diffDays <= 1) return 'soon'
+  return null
+}
+
+function formatDate(dateString) {
+  const date = new Date(dateString + 'T00:00:00')
+  return date.toLocaleDateString('es-ES', { day: 'numeric', month: 'short', year: 'numeric' })
+}
+
 function TaskItem({ task, onToggle, onDelete }) {
   const {
     attributes,
@@ -15,6 +31,9 @@ function TaskItem({ task, onToggle, onDelete }) {
     transform: CSS.Transform.toString(transform),
     transition
   }
+
+  const dueDateStatus = getDueDateStatus(task.due_date, task.completed)
+  const dueDateClass = dueDateStatus ? `due-date due-date--${dueDateStatus}` : 'due-date'
 
   return (
     <div
@@ -33,6 +52,11 @@ function TaskItem({ task, onToggle, onDelete }) {
       <span className={task.completed ? 'task-title completed' : 'task-title'}>
         {task.title}
       </span>
+      {task.due_date && (
+        <span className={dueDateClass}>
+          {formatDate(task.due_date)}
+        </span>
+      )}
       <button
         onClick={() => onDelete(task.id)}
         className="btn btn-delete"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -148,3 +148,33 @@ p {
   text-decoration: line-through;
   color: #999;
 }
+
+/* Date Input */
+.task-date-input {
+  padding: 0.5rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 0.875rem;
+}
+
+.task-date-input:focus {
+  outline: none;
+  border-color: #3498db;
+}
+
+/* Due Date Indicator */
+.due-date {
+  font-size: 0.8rem;
+  color: #999;
+  white-space: nowrap;
+}
+
+.due-date--overdue {
+  color: #e74c3c;
+  font-weight: 600;
+}
+
+.due-date--soon {
+  color: #f39c12;
+  font-weight: 600;
+}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -8,11 +8,13 @@ export async function fetchTasks() {
 }
 
 // POST /api/tasks - Crear nueva tarea
-export async function createTask(title) {
+export async function createTask(title, dueDate) {
+  const task = { title }
+  if (dueDate) task.due_date = dueDate
   const response = await fetch(`${API_BASE_URL}/tasks`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ task: { title } })
+    body: JSON.stringify({ task })
   })
   if (!response.ok) throw new Error('Failed to create task')
   return response.json()

--- a/plans/task-due-date.md
+++ b/plans/task-due-date.md
@@ -1,0 +1,164 @@
+# Feature: Fecha límite opcional en tareas
+
+## Descripción de la Funcionalidad
+Añadir un campo de fecha límite (due date) opcional a las tareas. Los usuarios podrán establecer, modificar o eliminar una fecha de vencimiento al crear o editar una tarea. Las tareas con fecha límite vencida se mostrarán con un indicador visual para alertar al usuario.
+
+## Historia de Usuario
+Como usuario de la aplicación de tareas
+Quiero poder asignar una fecha límite opcional a mis tareas
+Para que pueda organizar mejor mi trabajo y saber qué tareas son urgentes
+
+## Planteamiento del Problema
+Actualmente las tareas solo tienen título y estado de completado. No hay forma de indicar cuándo debe completarse una tarea, lo que dificulta la priorización y planificación del trabajo.
+
+## Propuesta de Solución
+Añadir un campo `due_date` de tipo `date` (nullable) a la tabla `tasks`. En el frontend, incluir un input de tipo date en el formulario de creación y mostrar la fecha límite en cada tarea con indicadores visuales (vencida en rojo, próxima a vencer en naranja).
+
+## Archivos Relevantes
+Usa estos ficheros para implementar la funcionalidad:
+
+- `backend/app/models/task.rb` — Modelo Task, añadir validación de due_date
+- `backend/app/controllers/api/tasks_controller.rb` — Permitir due_date en task_params
+- `backend/db/schema.rb` — Referencia del esquema actual
+- `backend/test/models/task_test.rb` — Tests del modelo Task
+- `backend/test/controllers/api/tasks_controller_test.rb` — Tests del controlador
+- `backend/test/fixtures/tasks.yml` — Fixtures de test
+- `frontend/src/App.jsx` — Componente raíz, pasar due_date en handlers
+- `frontend/src/services/api.js` — Función createTask necesita aceptar due_date
+- `frontend/src/components/TaskForm.jsx` — Formulario de creación, añadir input date
+- `frontend/src/components/TaskItem.jsx` — Mostrar fecha límite e indicador visual
+- `frontend/src/index.css` — Estilos para indicadores de fecha
+- `frontend/src/__tests__/TaskForm.test.jsx` — Tests del formulario
+- `frontend/src/__tests__/TaskItem.test.jsx` — Tests del item
+- `frontend/src/__tests__/App.test.jsx` — Tests de integración del App
+
+### Ficheros Nuevos
+- `backend/db/migrate/XXXXXX_add_due_date_to_tasks.rb` — Migración para añadir columna due_date
+
+## Plan de Implementación
+### Fase 1: Fundamentos
+Crear la migración de base de datos para añadir el campo `due_date` (tipo `date`, nullable) a la tabla `tasks`. Actualizar el modelo y el controlador para aceptar y exponer el nuevo campo.
+
+### Fase 2: Implementación Principal
+Modificar el frontend para incluir un date picker en el formulario de creación, pasar `due_date` a través del servicio API, y mostrar la fecha en cada tarea con indicadores visuales de estado (vencida, próxima, normal).
+
+### Fase 3: Integración
+Asegurar que todas las operaciones existentes (crear, actualizar, reordenar, eliminar) funcionan correctamente con el nuevo campo. Actualizar tests en backend y frontend.
+
+## Tareas Paso a Paso
+IMPORTANTE: Ejecuta cada paso en orden, de arriba a abajo.
+
+### Paso 1: Crear migración de base de datos
+- Generar migración: `cd backend && bin/rails generate migration AddDueDateToTasks due_date:date`
+- Ejecutar migración: `cd backend && bin/rails db:migrate`
+- Verificar que `db/schema.rb` incluye la columna `due_date`
+
+### Paso 2: Actualizar modelo Task
+- En `backend/app/models/task.rb`, añadir validación opcional de `due_date`:
+  - `validates :due_date, comparison: { greater_than_or_equal_to: -> { Date.today } }, allow_nil: true, on: :create`
+- Ejecutar `cd backend && bin/rails annotaterb models` para actualizar anotaciones del modelo
+
+### Paso 3: Actualizar controlador
+- En `backend/app/controllers/api/tasks_controller.rb`, añadir `:due_date` a `task_params`
+
+### Paso 4: Actualizar fixtures y tests del backend
+- Añadir `due_date` a algunas fixtures en `backend/test/fixtures/tasks.yml` (al menos una con fecha futura y una sin fecha)
+- En `backend/test/models/task_test.rb`:
+  - Test: tarea válida con due_date nil
+  - Test: tarea válida con due_date futura
+  - Test: tarea inválida con due_date pasada al crear
+- En `backend/test/controllers/api/tasks_controller_test.rb`:
+  - Test: crear tarea con due_date
+  - Test: crear tarea sin due_date
+  - Test: actualizar due_date de una tarea existente
+  - Test: eliminar due_date (poner a null)
+- Ejecutar tests: `cd backend && bin/rails test`
+
+### Paso 5: Actualizar servicio API del frontend
+- En `frontend/src/services/api.js`, modificar `createTask` para aceptar un objeto con `title` y `due_date` opcionales (o parámetros separados)
+- Asegurar que `updateTask` ya soporta enviar `due_date`
+
+### Paso 6: Actualizar TaskForm
+- En `frontend/src/components/TaskForm.jsx`:
+  - Añadir estado `dueDate` (inicialmente vacío)
+  - Añadir input `<input type="date">` al lado del input de título
+  - Pasar `dueDate` al handler `onCreateTask`
+  - Limpiar `dueDate` tras envío exitoso
+
+### Paso 7: Actualizar App.jsx
+- En `frontend/src/App.jsx`:
+  - Modificar `handleCreateTask` para recibir y enviar `due_date` al API
+  - Asegurar que la respuesta del API con `due_date` se refleja en el estado
+
+### Paso 8: Actualizar TaskItem
+- En `frontend/src/components/TaskItem.jsx`:
+  - Mostrar la fecha límite junto al título si existe
+  - Añadir indicador visual:
+    - Rojo si la fecha ya pasó y la tarea no está completada
+    - Naranja si la fecha es hoy o mañana y la tarea no está completada
+    - Gris/normal en otros casos o si la tarea está completada
+  - Formatear la fecha de forma legible (ej: "4 mar 2026")
+
+### Paso 9: Actualizar estilos CSS
+- En `frontend/src/index.css`:
+  - Estilos para `.due-date` (tamaño, color base gris)
+  - Estilos para `.due-date--overdue` (color rojo `#e74c3c`)
+  - Estilos para `.due-date--soon` (color naranja `#f39c12`)
+  - Estilos para el input date en el formulario
+
+### Paso 10: Actualizar tests del frontend
+- En `frontend/src/__tests__/TaskForm.test.jsx`:
+  - Test: renderiza input de fecha
+  - Test: envía tarea con fecha límite
+  - Test: envía tarea sin fecha límite
+  - Test: limpia fecha tras envío
+- En `frontend/src/__tests__/TaskItem.test.jsx`:
+  - Test: muestra fecha límite cuando existe
+  - Test: no muestra fecha cuando no existe
+  - Test: muestra indicador rojo cuando está vencida
+  - Test: muestra indicador naranja cuando es próxima
+- En `frontend/src/__tests__/App.test.jsx`:
+  - Test: crear tarea con fecha límite
+
+### Paso 11: Validación final
+- Ejecutar los `Comandos de Validación` para confirmar que todo funciona sin regresiones
+
+## Estrategia de Testing
+### Tests Unitarios
+- Modelo Task: validaciones de due_date (nil permitido, fecha futura en creación, fecha pasada rechazada en creación)
+- Componente TaskForm: renderizado del input date, envío con y sin fecha
+- Componente TaskItem: renderizado condicional de fecha, clases CSS de indicadores
+
+### Tests de Integración
+- Controlador: CRUD completo con due_date (crear con fecha, actualizar fecha, eliminar fecha)
+- App.jsx: flujo completo de crear tarea con fecha límite
+
+### Casos Límite
+- Crear tarea sin fecha límite (debe funcionar como antes)
+- Crear tarea con fecha de hoy (debe ser válida)
+- Actualizar tarea existente para añadir fecha límite
+- Actualizar tarea existente para quitar fecha límite (poner a null)
+- Tarea con fecha vencida que se marca como completada (indicador visual cambia)
+- Tarea con fecha vencida que se actualiza (validación de fecha pasada no aplica en update, solo en create)
+
+## Criterios de Aceptación
+- El campo due_date es opcional: las tareas pueden crearse sin fecha límite
+- El formulario de creación incluye un date picker opcional
+- Las tareas muestran su fecha límite cuando existe
+- Las tareas vencidas no completadas muestran indicador rojo
+- Las tareas próximas a vencer (hoy/mañana) no completadas muestran indicador naranja
+- Las tareas completadas no muestran indicadores de urgencia independientemente de la fecha
+- Todas las operaciones existentes (crear, completar, reordenar, eliminar) siguen funcionando
+- Los tests de backend y frontend pasan sin errores
+
+## Comandos de Validación
+Ejecuta cada comando para validar que la funcionalidad funciona correctamente sin regresiones.
+
+- `cd /home/work/anjana_master/entaina/backend && bin/rails test` - Ejecuta los tests del backend para validar que la funcionalidad funciona sin regresiones
+- `cd /home/work/anjana_master/entaina/frontend && npm test` - Ejecuta los tests del frontend para validar que la funcionalidad funciona sin regresiones
+
+## Notas
+- La validación de fecha futura solo aplica en creación (`on: :create`), no en actualización, para permitir que tareas con fechas que ya pasaron puedan editarse sin problemas
+- Se usa `type="date"` nativo del navegador para el date picker, sin dependencias adicionales
+- El formato de visualización de fecha se hará con `toLocaleDateString('es-ES')` para consistencia con el idioma
+- No se requieren nuevas gemas ni paquetes npm


### PR DESCRIPTION
## Summary
Adds an optional `due_date` field to tasks, allowing users to set deadlines. The feature includes visual indicators in the UI to highlight overdue tasks and tasks due today.

Closes #1

## Implementation Plan
See implementation plan in issue #1 comments

## Changes
- Added `due_date` optional date column to tasks table via migration
- Updated `Task` model with validation (due_date must not be in the past on creation)
- Updated `TasksController` to permit and expose `due_date` in API responses
- Added date picker input to `TaskForm` component
- Updated `TaskItem` component with visual indicators for overdue/due-today tasks
- Added CSS styles for overdue (red) and due-today (orange) task highlighting
- Updated frontend API service to include `due_date` in task payloads
- Full test coverage: model, controller, and React component tests

## ADW
ADW ID:
